### PR TITLE
add settings for connect web3

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,7 +37,8 @@ export default {
   ** https://nuxtjs.org/guide/plugins
   */
   plugins: [
-    '@/plugins/element-ui'
+    '@/plugins/element-ui',
+    '@/plugins/web3.js'
   ],
   /*
   ** Auto import components


### PR DESCRIPTION
web3のプラグインファイルが読み込まれていなかったのでnuxt-configにてパスを追記しました。

以下の画像にてweb3のプラグインを読み込んでいる様子を示す
![image](https://user-images.githubusercontent.com/55534054/97097761-ffb7e480-16b7-11eb-9738-c863540684ac.png)
