### PR TITLE
アカウントを取得しレポートコントラクトの実装#70

### DIFF
--- a/components/folder.vue
+++ b/components/folder.vue
@@ -18,34 +18,23 @@ import { db,firebase } from '~/plugins/firebase'
 export default {
     data(){
         return{
-            shareReports:[]
+            shareReports:[],
+            userAddress:null
         }
     },
-     mounted () {
-        // db.collection('reports').get()
-        //     .then((querySnapshot) => {
-        //     querySnapshot.forEach((doc) => {
-        //         //TODO: web3で現在のメタマスクアカウントを取得する
-        //         const userAddress = '0x5A2B93AB2bAe9D319b49d1AeB54840f1C8D0918c'
-        //         // const userAddress = '0xcD3Ab788fC0343C63d393000Ae70Ece96336d4a0'
-        //            if(doc.data().shareUser == userAddress){
-        //             //    console.log(doc.data())
-        //             //    console.log("this shareUser is ",doc.data().shareUser)
-        //                this.shareReports.push(doc.data())
-        //             //    console.log(this.shareReports)
-        //            }
-        //     })
-        //     })
-        db.collection('reports').onSnapshot((snapshot)=>{
-            snapshot.docChanges().forEach((change)=>{
-            const doc = change.doc
-            const userAddress = '0x5A2B93AB2bAe9D319b49d1AeB54840f1C8D0918c'
-            // const userAddress = '0xcD3Ab788fC0343C63d393000Ae70Ece96336d4a0'
-          if(change.type === 'added' && doc.data().shareUser == userAddress){
-            this.shareReports.push({id: doc.id, ...doc.data()})
-          }
-        })
-      })    
+     async mounted () {
+        let accounts = await this.$web3.eth.getAccounts()
+        this.userAddress = accounts[0]
+        if(this.userAddress != null){
+            db.collection('reports').onSnapshot((snapshot)=>{
+                snapshot.docChanges().forEach((change)=>{
+                const doc = change.doc
+              if(change.type === 'added' && doc.data().shareUser == this.userAddress){
+                this.shareReports.push({id: doc.id, ...doc.data()})
+              }
+            })
+          })    
+        }
      }
 }
 </script>

--- a/pages/homePage.vue
+++ b/pages/homePage.vue
@@ -6,6 +6,7 @@
         <Folder/>
       </div>
       <div class="main-content">
+        <h5>現在ログインしているアカウントは{{userAddress}}</h5>
         <el-button @click="RP()">RPを実行するボタン</el-button>
         <!-- ランキングコンテンツはcomponentにしてもいいかも -->
         <div class="rank-content">
@@ -39,12 +40,13 @@ export default {
   data(){
     return{
       reports:[],
+      users:[],
+      userAddress:null,
       reportsAbove:[],
       RP1Table:[],
       RP2Table:[],
       RPTable:[],
       downloadsArray:[],
-      users:[],
       tokens:[],
       rp2Receiver:[],
       hitNumber:null,
@@ -52,25 +54,49 @@ export default {
       // receiverIndex:null
     }
   },
-  mounted(){
-        db.collection('reports').orderBy('downloads', 'desc').get().then((querySnapshot) => {
-            querySnapshot.forEach((doc) => {
-                // console.log(doc.id, "=>" ,doc.data())
-                this.reports.push(doc.data())
-                // console.log(this.reports)
-                this.report = this.reports[0]
-
-            })
+  async mounted(){
+      await db.collection('users').get().then((querySnapshot) =>{
+          querySnapshot.forEach((doc) => {
+              this.users.push(doc.data())
+              console.log(this.users)
+          })
+      })
+        let accounts = await this.$web3.eth.getAccounts()
+        this.userAddress = accounts[0]
+        // console.log(this.userAddress)
+      let count=0;
+      for(let i=0;i < this.users.length;i++){
+        if(this.users[i].address == this.userAddress){
+          count++;
+        }
+      }
+      if(count == 0){
+        await db.collection('users').doc(this.userAddress).set({
+          address:this.userAddress,
+          purchased_token_amount:0,
+          shares:0,
+          tokens:0
+          //TODO: 他にも初期値を設定するところがあるかもしれないので注意
         })
+      }
+
+
+    db.collection('reports').orderBy('downloads', 'desc').get().then((querySnapshot) => {
+        querySnapshot.forEach((doc) => {
+            this.reports.push(doc.data())
+            this.report = this.reports[0]
+
+        })
+    })
 
   },
   methods:{
     async RP(){
-        await db.collection('users').get().then((querySnapshot) => {
-            querySnapshot.forEach((doc) => {
-                this.users.push(doc.data())
-            })
-        })
+        // await db.collection('users').get().then((querySnapshot) => {
+        //     querySnapshot.forEach((doc) => {
+        //         this.users.push(doc.data())
+        //     })
+        // })
       this.RP1()
       
       this.RP2()

--- a/pages/homePage.vue
+++ b/pages/homePage.vue
@@ -92,11 +92,6 @@ export default {
   },
   methods:{
     async RP(){
-        // await db.collection('users').get().then((querySnapshot) => {
-        //     querySnapshot.forEach((doc) => {
-        //         this.users.push(doc.data())
-        //     })
-        // })
       this.RP1()
       
       this.RP2()

--- a/pages/uploadPage.vue
+++ b/pages/uploadPage.vue
@@ -158,11 +158,11 @@ export default {
 
     };
   },
-  mounted(){
+  async mounted(){
     //TODO: web3で現在のメタマスクアカウントを取得する
-        const userAddress = '0x5A2B93AB2bAe9D319b49d1AeB54840f1C8D0918c'
-        // const userAddress = '0xcD3Ab788fC0343C63d393000Ae70Ece96336d4a0'
-        const userRef = db.collection('users').doc(userAddress)
+    let accounts = await this.$web3.eth.getAccounts()
+    this.userAddress = accounts[0]
+    const userRef = db.collection('users').doc(this.userAddress)
         userRef.get().then((doc)=>{
           this.user = doc.data()
         })
@@ -191,10 +191,8 @@ export default {
         // console.log("ipfsHash is ",this.ipfsHash)
       })
       //TODO: ReportInfoコントラクトからハッシュ値を格納するsetReportを呼び出す
-      //
       //   firestoreにレポートの情報を追加する
-        const userAddress = '0x5A2B93AB2bAe9D319b49d1AeB54840f1C8D0918c'
-        db.collection('users').doc(userAddress).update({
+        db.collection('users').doc(this.userAddress).update({
           //シェアしたレポートの数をインクリメントする。これがレポートのインデックスになる
           shares: firebase.firestore.FieldValue.increment(1),
         })

--- a/pages/uploadPage.vue
+++ b/pages/uploadPage.vue
@@ -159,7 +159,6 @@ export default {
     };
   },
   async mounted(){
-    //TODO: web3で現在のメタマスクアカウントを取得する
     let accounts = await this.$web3.eth.getAccounts()
     this.userAddress = accounts[0]
     const userRef = db.collection('users').doc(this.userAddress)
@@ -188,9 +187,7 @@ export default {
       //   IPFSにアップロード
       await ipfs.add(this.setBuffer).then((value) => {
         this.ipfsHash = value.path
-        // console.log("ipfsHash is ",this.ipfsHash)
       })
-      //TODO: ReportInfoコントラクトからハッシュ値を格納するsetReportを呼び出す
       let ret = await this.$reportInfoContract.methods.setReport(this.ipfsHash).send({from: this.userAddress})
       console.log(ret)
       //   firestoreにレポートの情報を追加する

--- a/pages/uploadPage.vue
+++ b/pages/uploadPage.vue
@@ -184,20 +184,22 @@ export default {
       }
 
     },
-    reportUpload() {
+    async reportUpload() {
       //   IPFSにアップロード
-      ipfs.add(this.setBuffer).then((value) => {
+      await ipfs.add(this.setBuffer).then((value) => {
         this.ipfsHash = value.path
         // console.log("ipfsHash is ",this.ipfsHash)
       })
       //TODO: ReportInfoコントラクトからハッシュ値を格納するsetReportを呼び出す
+      let ret = await this.$reportInfoContract.methods.setReport(this.ipfsHash).send({from: this.userAddress})
+      console.log(ret)
       //   firestoreにレポートの情報を追加する
-        db.collection('users').doc(this.userAddress).update({
+      await db.collection('users').doc(this.userAddress).update({
           //シェアしたレポートの数をインクリメントする。これがレポートのインデックスになる
           shares: firebase.firestore.FieldValue.increment(1),
-        })
+      })
         this.user.shares++
-        db.collection('reports').add({
+      await db.collection('reports').add({
           university: this.ruleForm.university,
           grade: this.ruleForm.grade,
           semester: this.ruleForm.semester,
@@ -206,7 +208,7 @@ export default {
           index: this.user.shares,
           shareUser: this.user.address,
           downloads: 0
-        })
+      })
       if (this.active++ > 2) this.active = 0;
       this.$notify({
         title: '成功',


### PR DESCRIPTION
Metamaskのアカウントを取得した際に初めてのアカウントだったらfirestoreに格納する処理の実装をしました。

そのアカウントを識別してそのアカウントが共有したレポートのみの表示をしました。

レポートを共有するとき、現在のMetamaskアカウントのアドレスの情報をfirestoreに格納するようにしました。

レポートを共有するとき、レポートコントラクトを動かし、MetamaskとのコネクトからEthereumにハッシュ値を格納するようにしました。以下の画像にてMetamaskが動いていることを示す。
![image](https://user-images.githubusercontent.com/55534054/97101112-d742e100-16dd-11eb-9f68-ecb7c6a68781.png)
