### PR TITLE
walletの送信のUI/UXの実装 #73

### DIFF
--- a/assets/styles/reset.css
+++ b/assets/styles/reset.css
@@ -7,3 +7,9 @@
 body{
     background-color:#f4f4f4;
 }
+
+.v-modal{
+  position: static;
+  z-index: 10;
+  opacity: 1.0;
+}

--- a/pages/myPage.vue
+++ b/pages/myPage.vue
@@ -81,7 +81,7 @@ export default {
       if (this.loading) {
         return;
       }
-      await this.$confirm(this.form.amount+'RPTを本当に購入しますか？')
+      await this.$confirm(this.form.amount + 'RPTを本当に購入しますか？')
         .then(_ => {
           this.loading = true;
           this.timer = setTimeout(() => {
@@ -92,9 +92,10 @@ export default {
             }, 400);
           }, 2000);
         })
+      await this.purchaseToken()
         .catch(_ => {
         });
-      await this.purchaseToken()
+
     },
     async cancelForm() {
       this.loading = false;
@@ -169,5 +170,21 @@ p {
 .wallet-detail_content {
   /* max-height: 50vh; */
   overflow: scroll;
+}
+
+element.style {
+  width: 26%;
+}
+
+.el-drawer.ltr, .el-drawer__container {
+  top: 50px;
+  bottom: 1;
+  width: 50%;
+  height: 57%;
+}
+
+.el-input__inner {
+  width: 93%;
+  margin-left: -30px;
 }
 </style>


### PR DESCRIPTION
トークン購入用のdrawerとpurchaseToken関数追加し、マイページでRPTを購入できるようにしました。
<img width="1792" alt="スクリーンショット 2020-11-13 11 22 35" src="https://user-images.githubusercontent.com/57268381/99020987-05139b00-25a3-11eb-9e8e-c76d7036a356.png">
<img width="1247" alt="スクリーンショット 2020-11-13 11 23 10" src="https://user-images.githubusercontent.com/57268381/99020993-080e8b80-25a3-11eb-956f-bc51f12f4aab.png">
<img width="357" alt="スクリーンショット 2020-11-13 11 29 29" src="https://user-images.githubusercontent.com/57268381/99021208-80754c80-25a3-11eb-9903-dabf7f630096.png">


