### PR TITLE
購入したレポートをマイページで表示　#91 #89

### DIFF
--- a/assets/styles/reset.css
+++ b/assets/styles/reset.css
@@ -1,7 +1,7 @@
 *{
     margin: 0;
     z-index: 0;
-    outline: 1px solid rgb(238, 216, 245);
+    /* outline: 1px solid rgb(238, 216, 245); */
 }
 
 body{

--- a/assets/styles/reset.css
+++ b/assets/styles/reset.css
@@ -1,7 +1,7 @@
 *{
     margin: 0;
     z-index: 0;
-    /* outline: 1px solid rgb(238, 216, 245); */
+    outline: 1px solid rgb(238, 216, 245);
 }
 
 body{

--- a/components/header.vue
+++ b/components/header.vue
@@ -37,8 +37,9 @@ export default {
 .header-content {
   display: flex;
   width: 100%;
-  height: 6vh;
+  height: 60px;
   background-color: #f4f4f4;
+
 }
 
 .reportoken-logo_header {

--- a/pages/folders/_id.vue
+++ b/pages/folders/_id.vue
@@ -82,7 +82,7 @@ export default {
           .getReport(this.reportIndex, this.shareUserAddress)
           .call();
         this.reportHash = ret;
-        // break;
+        break;
       }
       if (this.shareUserAddress == this.userAddress) {
         this.canWatch = true;
@@ -90,7 +90,7 @@ export default {
           .getOwnerReport(this.reportIndex)
           .call();
         this.reportHash = ret;
-        // break;
+        break;
       }
     }
   },

--- a/pages/folders/_id.vue
+++ b/pages/folders/_id.vue
@@ -126,7 +126,6 @@ export default {
           .transfer(this.shareUserAddress, this.sendValue)
           .send({ from: this.userAddress });
         this.number = Ret;
-        //TODO: 自分のユーザーの購入リストにreportdocを追加する.
         await db
           .collection("users")
           .doc(this.userAddress)

--- a/pages/myPage.vue
+++ b/pages/myPage.vue
@@ -133,8 +133,6 @@ export default {
           from: this.ownAddress,
           value: this.sendValue,
         });
-      console.log(this.$reportTokenContract);
-      console.log(ret);
       this.number = ret;
     },
   },
@@ -162,8 +160,6 @@ export default {
             if (this.buying.length != 0 && this.buying != null) {
               let count = 0;
               for (let i = 0; i < this.buying.length; i++) {
-                console.log(this.buying[this.count].report_doc);
-                console.log("doc id is", doc.id);
                 if (this.buying[count].report_doc == doc.id) {
                   this.purchasedReport.push(doc.data());
                 }
@@ -172,7 +168,6 @@ export default {
             }
           });
         });
-      console.log("purchasedReport is", this.purchasedReport);
     }
   },
 };

--- a/pages/myPage.vue
+++ b/pages/myPage.vue
@@ -51,6 +51,9 @@
             </div>
           </el-drawer>
         </div>
+        <div class="purchased-report">
+          <Filecards :reports="purchasedReport" />
+        </div>
         <div class="wallet-detail_content"></div>
       </div>
       <div class="side-content">
@@ -88,6 +91,9 @@ export default {
       form: {
         amount: null,
       },
+      purchasedReport: [],
+      buying: [],
+      count: 0,
     };
   },
   methods: {
@@ -135,17 +141,36 @@ export default {
     let accounts = await this.$web3.eth.getAccounts();
     this.ownAddress = accounts[0];
     if (this.ownAddress != null) {
-      db.collection("reports").onSnapshot((snapshot) => {
-        snapshot.docChanges().forEach((change) => {
-          const doc = change.doc;
-          if (
-            change.type === "added" &&
-            doc.data().shareUser == this.ownAddress
-          ) {
-            this.shareReports.push({ id: doc.id, ...doc.data() });
-          }
+      db.collection("users")
+        .doc(this.ownAddress)
+        .collection("buying_list")
+        .get()
+        .then((querySnapshot) => {
+          querySnapshot.forEach((doc) => {
+            this.buying.push(doc.data());
+          });
         });
-      });
+      await db.collection("reports")
+        .get()
+        .then((querySnapshot) => {
+          querySnapshot.forEach((doc) => {
+            if (doc.data().shareUser == this.ownAddress) {
+              this.shareReports.push({ id: doc.id, ...doc.data() });
+            }
+            if (this.buying.length != 0 && this.buying != null) {
+              let count = 0;
+              for (let i = 0; i < this.buying.length; i++) {
+                console.log(this.buying[this.count].report_doc);
+                console.log("doc id is", doc.id);
+                if (this.buying[count].report_doc == doc.id) {
+                  this.purchasedReport.push(doc.data());
+                }
+                count++;
+              }
+            }
+          });
+        });
+      console.log("purchasedReport is",this.purchasedReport)
     }
   },
 };
@@ -164,7 +189,6 @@ h1 {
 p {
   margin-left: 10px;
 }
-
 
 .main-contents {
   min-height: 700px;

--- a/pages/myPage.vue
+++ b/pages/myPage.vue
@@ -52,6 +52,7 @@
           </el-drawer>
         </div>
         <div class="purchased-report">
+          <h3>購入したレポート</h3>
           <Filecards :reports="purchasedReport" />
         </div>
         <div class="wallet-detail_content"></div>
@@ -150,7 +151,8 @@ export default {
             this.buying.push(doc.data());
           });
         });
-      await db.collection("reports")
+      await db
+        .collection("reports")
         .get()
         .then((querySnapshot) => {
           querySnapshot.forEach((doc) => {
@@ -170,7 +172,7 @@ export default {
             }
           });
         });
-      console.log("purchasedReport is",this.purchasedReport)
+      console.log("purchasedReport is", this.purchasedReport);
     }
   },
 };

--- a/pages/uploadPage.vue
+++ b/pages/uploadPage.vue
@@ -29,12 +29,12 @@
                 prop="university"
                 style="margin-bottom: 5px"
               >
-                <el-input v-model="ruleForm.university">{{
+                <el-input v-model="ruleForm.university" class="input-form">{{
                   this.ruleForm.university
                 }}</el-input>
               </el-form-item>
               <el-form-item label="科目名" prop="subject">
-                <el-input v-model="ruleForm.subject">{{
+                <el-input v-model="ruleForm.subject" class="input-form">{{
                   this.ruleForm.subject
                 }}</el-input>
               </el-form-item>
@@ -269,6 +269,9 @@ export default {
 
 .input-form_contents {
   margin-top: 5px;
+}
+.input-form{
+  margin-left: 30px;
 }
 
 .next-step_btn {


### PR DESCRIPTION
購入したレポートをマイページ中央に表示させました。レポートの表示は以前と変わりません。
firestoreに購入リストを作成し、購入するたびにその購入リストに追加されるという形で実装しました。

![image](https://user-images.githubusercontent.com/55534054/99181477-44441680-2772-11eb-86b4-6e9594e6d8a9.png)

また、一度購入したレポート、共有したレポートはそもそも買うボタンを押すのはおかしいのでこれらに該当した場合のレポートは既にレポートが見れるようにしました。

#89　に関しては左側の余白を追加することで対応しました。(一行追加するだけだったのでついでにPR出します)
![image](https://user-images.githubusercontent.com/55534054/99181592-c5031280-2772-11eb-8fd4-8111896ea3fc.png)
